### PR TITLE
Restore part of the project and WIP RL agent train

### DIFF
--- a/nlns/generators/dataset.py
+++ b/nlns/generators/dataset.py
@@ -26,7 +26,7 @@ class IterableVRPDataset(torch.utils.data.IterableDataset):
         the generation of random instances.
         Infinitely many instances are generated, until StopIteration is raised
         by a torch.data.DataLoader.
-        
+
         Args:
             n_instances (int): Instances to generate.
             n_customer (Union[int, Tuple[int, int]]): Amount of customer
@@ -34,10 +34,10 @@ class IterableVRPDataset(torch.utils.data.IterableDataset):
                 the range in which customers will be sampled.
             solve (bool, optional): If True instances are solved using LKH-3. Defaults to False.
             lkh_path (str, optional): Path to LKH3 solver. Defaults to "executables/LKH".
-            lkh_pass (int, optional): Number of passes over LKH3 solver. 
+            lkh_pass (int, optional): Number of passes over LKH3 solver.
                 Defaults to None which corresponds to the number of customers.
                 The less the passes the better the solution.
-            lkh_runs (int, optional): Number of runs over LKH3 solver. 
+            lkh_runs (int, optional): Number of runs over LKH3 solver.
         """
         self.lkh = LKHSolver(lkh_path)
         self.lkh_pass = lkh_pass
@@ -45,12 +45,12 @@ class IterableVRPDataset(torch.utils.data.IterableDataset):
         self.nodes = n_customer
         self.n_instances = n_instances
         self.solve = solve
-        
+
     def _sample_nodes(self) -> int:
         """
         Returns:
             int: Number of nodes in the generated instance. The result varies depending on
-                 the initialization arguments. 
+                 the initialization arguments.
         """
         if type(self.nodes) == int:
             return self.nodes
@@ -76,15 +76,15 @@ class IterableVRPDataset(torch.utils.data.IterableDataset):
         worker_info = torch.utils.data.get_worker_info()
         to_generate = self.n_instances if worker_info is None \
                       else int(math.ceil(self.n_instances / float(worker_info.num_workers)))
-        
+
         for _ in range(to_generate):
             nodes = self._sample_nodes()
             elem = self.generate_instance(nodes)
-            
+
             if self.solve:
                 elem = self.lkh.solve(elem, max_steps=self.lkh_pass, runs=self.lkh_runs)
-                
-            yield elem 
+
+            yield elem
 
 
 class NazariDataset(IterableVRPDataset):

--- a/nlns/generators/nazari_generator.py
+++ b/nlns/generators/nazari_generator.py
@@ -22,7 +22,7 @@ def generate_nazari_instance(n_customers: int) -> VRPInstance:
         VRPInstance: Final VRPInstance.
     """
     capacity = np.interp(n_customers, [10, 20, 50, 100], [20, 30, 40, 50])
-    return VRPInstance(list(np.random.uniform(size=(2,))), 
-                       list(np.random.uniform(size=(n_customers, 2))), 
+    return VRPInstance(list(np.random.uniform(size=(2,))),
+                       list(np.random.uniform(size=(n_customers, 2))),
                        list(np.random.randint(1, 10, size=(n_customers,))),
                        capacity)

--- a/nlns/main/run_train.py
+++ b/nlns/main/run_train.py
@@ -3,41 +3,22 @@ import sys
 import torch
 import numpy as np
 
-sys.path.append("src")
+from nlns.utils.logging import MultipleLogger, ConsoleLogger, WandBLogger
+from nlns.operators.neural import NeuralProcedurePair
+from nlns.operators.destroy import DestroyPointBased, DestroyTourBased, ResGatedGCNDestroy, RandomDestroy
+from nlns.operators.repair import SCIPRepair, GreedyRepair, RLAgentRepair
+from nlns.models import VRPActorModel, VRPCriticModel
+from nlns.generators.dataset import NazariDataset
 
-from utils.logging import MultipleLogger, TabularConsoleLogger, WandBLogger
-from nlns.neural import NeuralProcedurePair
-from nlns.destroy import DestroyPointBased, DestroyTourBased, ResGatedGCNDestroy, RandomDestroy
-from nlns.repair import SCIPRepair, GreedyRepair
-from generators.dataset import NazariDataset
 
-parser = argparse.ArgumentParser(description='Train Neural VRP')
-parser.add_argument('-d', '--destroy', type=str, required=True, choices=["point", "tour", "random", "neural"])
-parser.add_argument('--destroy_path', type=str, required=False)
-parser.add_argument('-r', '--repair', type=str, required=True, choices=["greedy", "scip", "neural"])
-parser.add_argument('--repair_path', type=str, required=False)
-parser.add_argument('-n', '--n_customers', type=int, required=True)
-parser.add_argument('-p', '--destroy_percentage', type=float, required=True)
-parser.add_argument('-ts', '--train_samples', type=int, default=100000)
-parser.add_argument('-vs', '--val_samples', type=int, default=100)
-parser.add_argument('-bs', '--batch_size', type=int, default=256)
-parser.add_argument('-val-bs', '--validation_batch_size', type=int, default=256)
-parser.add_argument('-e', '--epochs', type=int, default=50)
-parser.add_argument('-vi', '--val_interval', type=int, required=False)
-parser.add_argument('-log', '--log_interval', type=int, required=False)
-parser.add_argument('--seed', type=int, required=False, default=42)
-
-args = parser.parse_args()
-
-if __name__ == "__main__":
+def main(args: argparse.Namespace):
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
 
-    assert args.destroy == "neural" or args.repair == "neural", "None of the specified operators needs to be trained"
-    assert args.destroy != "neural" or args.destroy_path != None, "Define a save path for the destroy operator using --destroy-path"
-    assert args.repair != "neural" or args.repair_path != None, "Define a save path for the repair operator using --repair-path"
-    
     device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    logger = MultipleLogger(loggers=[ConsoleLogger()])
+    if args.wandb_name is not None:
+        logger.add(WandBLogger(args.wandb_name))
 
     destroy_operator_map = {
         "point": lambda: DestroyPointBased(args.destroy_percentage),
@@ -49,7 +30,10 @@ if __name__ == "__main__":
 
     repair_operator_map = {
         "scip": lambda: SCIPRepair(),
-        "greedy": lambda: GreedyRepair()
+        "greedy": lambda: GreedyRepair(),
+        "neural": lambda: RLAgentRepair(
+            VRPActorModel(device=device), VRPCriticModel(), device=device,
+                          logger=logger)
     }
     repair_operator = repair_operator_map[args.repair]()
 
@@ -57,19 +41,44 @@ if __name__ == "__main__":
     # validation dataset is consolidated into a list to always use the same set
     validation = list(NazariDataset(args.val_samples, args.n_customers))
 
-    logger = TabularConsoleLogger(["phase", "epoch", "epoch_step", "target_solution", "incumbent_solution", "time"])
-
     npp = NeuralProcedurePair(destroy_operator, repair_operator)
-    npp.train(dataset, 
-              epochs=args.epochs, 
+    npp.train(dataset,
+              epochs=args.epochs,
               batch_size=args.batch_size,
               validation=validation,
               val_interval=args.val_interval,
               val_batch_size=args.validation_batch_size,
               log_interval=args.log_interval,
               logger=logger)
-    
+
     if args.destroy == "neural":
         destroy_operator.save(args.destroy_path)
     if args.repair == "neural":
         repair_operator.save(args.repair_path)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Train Neural VRP')
+    parser.add_argument('-d', '--destroy', type=str, required=True, choices=["point", "tour", "random", "neural"])
+    parser.add_argument('--destroy_path', type=str, required=False)
+    parser.add_argument('-r', '--repair', type=str, required=True, choices=["greedy", "scip", "neural"])
+    parser.add_argument('--repair_path', type=str, required=False)
+    parser.add_argument('-n', '--n_customers', type=int, required=True)
+    parser.add_argument('-p', '--destroy_percentage', type=float, required=True)
+    parser.add_argument('-ts', '--train_samples', type=int, default=100000)
+    parser.add_argument('-vs', '--val_samples', type=int, default=100)
+    parser.add_argument('-bs', '--batch_size', type=int, default=256)
+    parser.add_argument('-val-bs', '--validation_batch_size', type=int, default=256)
+    parser.add_argument('-e', '--epochs', type=int, default=50)
+    parser.add_argument('-vi', '--val_interval', type=int, required=False)
+    parser.add_argument('-log', '--log_interval', type=int, required=False)
+    parser.add_argument('--wandb-name', type=str, required=False, default=None)
+    parser.add_argument('--seed', type=int, required=False, default=42)
+
+    args = parser.parse_args()
+
+    assert args.destroy == "neural" or args.repair == "neural", "None of the specified operators needs to be trained"
+    assert args.destroy != "neural" or args.destroy_path != None, "Define a save path for the destroy operator using --destroy-path"
+    assert args.repair != "neural" or args.repair_path != None, "Define a save path for the repair operator using --repair-path"
+
+    main(args)

--- a/nlns/operators/destroy/res_gated_gcn_destroy.py
+++ b/nlns/operators/destroy/res_gated_gcn_destroy.py
@@ -13,7 +13,8 @@ from nlns.operators import DestroyProcedure
 #from nlns.neural import NeuralProcedure
 
 from nlns.models.dataloader import collate_fn
-from nlns.models import ResidualGatedGCNModel
+from nlns.models import ResGatedGCN
+
 
 class ResGatedGCNDestroy(DestroyProcedure):
     def __init__(self,
@@ -87,7 +88,7 @@ class ResGatedGCNDestroy(DestroyProcedure):
         """
         solution_copies = [deepcopy(s) for s in solutions]
         batch = collate_fn(solution_copies)
-        
+
         with torch.no_grad():
             prob, _ = self._heatmap_model(pyg)
             prob = prob.squeeze(0)
@@ -124,7 +125,7 @@ class ResGatedGCNDestroy(DestroyProcedure):
         """
         optimizer = torch.optim.Adam(self.heatmap_model.parameters(), lr=1e-3)
         return optimizer
-    
+
     def _evaluate(self, data: List[VRPSolution]) -> Tuple[torch.Tensor, torch.Tensor, Dict]:
         """
         Perform a training step on the procedure.

--- a/nlns/operators/repair/greedy_repair.py
+++ b/nlns/operators/repair/greedy_repair.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from instances import VRPSolution
+from nlns.instances import VRPSolution
 from nlns.operators import RepairProcedure
 from nlns.operators.initial.nearest_neighbor import closest_locations
 

--- a/nlns/operators/repair/rl_agent_repair.py
+++ b/nlns/operators/repair/rl_agent_repair.py
@@ -6,8 +6,8 @@ import numpy as np
 import torch.nn.functional as F
 from torch import optim
 
-from nlns import RepairProcedure
-from nlns.neural import NeuralProcedure
+from nlns.operators import RepairProcedure
+from nlns.operators.neural import NeuralProcedure
 from nlns.instances.vrp_neural_solution import VRPNeuralSolution
 from nlns.models import VRPActorModel, VRPCriticModel
 
@@ -54,11 +54,11 @@ class RLAgentRepair(NeuralProcedure, RepairProcedure):
         self.rewards = []
         self.diversity_values = []
 
-    def _train_step(self, opposite_procedure, train_batch):
-        opposite_procedure.multiple(train_batch)
-        costs_destroyed = [solution.cost() for solution in train_batch]
+    def _train_step(self, train_batch):
+        # opposite_procedure.multiple(train_batch)
+        costs_destroyed = [solution.cost for solution in train_batch]
         _, tour_logp, critic_est = self.multiple(train_batch)
-        costs_repaired = [solution.cost() for solution in train_batch]
+        costs_repaired = [solution.cost for solution in train_batch]
 
         # Reward/Advantage computation
         reward = np.array(costs_repaired) - np.array(costs_destroyed)

--- a/nlns/utils/logging.py
+++ b/nlns/utils/logging.py
@@ -1,0 +1,73 @@
+from abc import ABC, abstractmethod
+from numbers import Number
+from typing import Dict, List
+
+import wandb
+
+
+class Logger(ABC):
+    @abstractmethod
+    def new_run(self, run_name: str):
+        pass
+
+    @abstractmethod
+    def log(self, info: Dict[str, Number], phase: str):
+        pass
+
+
+class EmptyLogger(Logger):
+    """Drop all logs, to be used as default logger."""
+
+    def new_run(self, run_name: str):
+        pass
+
+    def log(self, info: Dict[str, Number], phase: str):
+        pass
+
+
+class WandBLogger(Logger):
+    def __init__(self, username: str, project: str = "NeuRouting"):
+        # self.model = model
+        self.project = project
+        self.username = username
+
+    def new_run(self, run_name=None):
+        wandb.init(name=run_name, project=self.project, entity=self.username)
+        # wandb.watch(self.model)
+
+    def log(self, info: Dict[str, Number], phase: str):
+        keys = []
+        for k in info.keys():
+            keys.append(f"{phase}/{k}")
+        info = dict(zip(keys, list(info.values())))
+        wandb.log(info)
+
+
+class ConsoleLogger(Logger):
+    def new_run(self, run_name: str):
+        pass
+
+    def log(self, info: Dict[str, Number], phase: str):
+        print(f"[{phase.upper()}]")
+        for k, v in info.items():
+            print(f"{k}: {v}")
+
+
+class MultipleLogger(Logger):
+    def __init__(self, loggers: List[Logger]):
+        self.loggers = set() if loggers is None else set(loggers)
+
+    def add(self, logger: Logger):
+        self.loggers.add(logger)
+
+    def remove(self, logger: Logger):
+        self.loggers.remove(logger)
+
+    def new_run(self, run_name: str):
+        for logger in self.loggers:
+            logger.new_run(run_name)
+
+    def log(self, info: Dict[str, Number], phase: str):
+        for logger in self.loggers:
+            logger.log(info, phase)
+


### PR DESCRIPTION
Many modules that were unused would also be unusable, as the import structure was destroyed by the previous project refactor. Some of it was restored, in particular, enough of it to make `nlns.main.run_train` usable for training of the RL agent. It is now possible to run it through: `python -m nlns.main.run_train [options...]`

It can only train the RL agent, badly (probably there are still some compatibility issues since I patched it brainlessly). In the near future it will be imperative to find a proper way to train both main neural operators together (OR drop this idea entirely).

All main scripts shall finally be put inside the main package and designed to be invoked through their namespace (`python -m`).